### PR TITLE
Fix code scanning alert no. 1: Accepting unknown SSH host keys when using Paramiko

### DIFF
--- a/main.py
+++ b/main.py
@@ -173,7 +173,7 @@ def ssh_connect(args):
         print_err_msg(Error.AUTH)
 
     ssh_client = paramiko.SSHClient()
-    ssh_client.set_missing_host_key_policy(paramiko.AutoAddPolicy())
+    ssh_client.set_missing_host_key_policy(paramiko.RejectPolicy())
 
     try:
         print_status(


### PR DESCRIPTION
Fixes [https://github.com/kareemagha/zse/security/code-scanning/1](https://github.com/kareemagha/zse/security/code-scanning/1)

To fix the problem, we need to replace the use of `AutoAddPolicy` with `RejectPolicy` in the `ssh_connect` function. This change ensures that the SSH client will only connect to hosts with known and verified keys, thereby preventing potential man-in-the-middle attacks.

- Change the `set_missing_host_key_policy` method call to use `RejectPolicy` instead of `AutoAddPolicy`.
- Ensure that the necessary import for `RejectPolicy` is present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
